### PR TITLE
Fixed #28 #30 #31

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -12,8 +12,8 @@ android {
         applicationId "app.milanherke.mystudiez"
         minSdkVersion 23
         targetSdkVersion 28
-        versionCode 1
-        versionName "1.0.0"
+        versionCode 2
+        versionName "1.0.1"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
     buildTypes {

--- a/app/src/main/java/app/milanherke/mystudiez/Exam.kt
+++ b/app/src/main/java/app/milanherke/mystudiez/Exam.kt
@@ -2,6 +2,7 @@ package app.milanherke.mystudiez
 
 import android.os.Parcelable
 import kotlinx.android.parcel.Parcelize
+import java.util.*
 
 /**
  * Data [Parcelable] subclass.
@@ -19,9 +20,9 @@ data class Exam(
     var name: String,
     var description: String,
     var subjectId: String,
-    var date: String,
-    var reminder: String,
+    var date: Date,
+    var reminder: Date? = null,
     var id: String = ""
 ) : Parcelable {
-    constructor() : this("", "", "", "", "", "")
+    constructor() : this("", "", "", Date(), null, "")
 }

--- a/app/src/main/java/app/milanherke/mystudiez/ExamDetailsFragment.kt
+++ b/app/src/main/java/app/milanherke/mystudiez/ExamDetailsFragment.kt
@@ -57,6 +57,7 @@ class ExamDetailsFragment : Fragment() {
 
         // Avoiding problems with smart-cast
         val exam = exam
+        val examReminder = exam?.reminder
         val subject = subject
 
         if (exam != null && subject != null) {
@@ -64,8 +65,8 @@ class ExamDetailsFragment : Fragment() {
             exam_details_name_value.text = exam.name
             exam_details_desc_value.text = exam.description
             exam_details_subject_value.text = subject.name
-            exam_details_date_value.text = exam.date
-            exam_details_reminder_value.text = exam.reminder
+            exam_details_date_value.text = CalendarUtils.dateToString(exam.date, false)
+            exam_details_reminder_value.text = if (examReminder == null) getString(R.string.add_edit_lesson_btn) else CalendarUtils.dateToString(examReminder, true)
         }
     }
 

--- a/app/src/main/java/app/milanherke/mystudiez/ExamsFragment.kt
+++ b/app/src/main/java/app/milanherke/mystudiez/ExamsFragment.kt
@@ -148,7 +148,8 @@ class ExamsFragment : Fragment(), ExamsRecyclerViewAdapter.OnExamClickListener {
         viewModel.examsListLiveData.observe(
             this,
             Observer { list ->
-                examsAdapter.swapExamsList(list)
+                val sortedList = ArrayList(list.sortedWith(compareBy(Exam::name)))
+                examsAdapter.swapExamsList(sortedList)
                 if (exam_list != null && list.size != 0) Animations.runLayoutAnimation(exam_list)
             }
         )

--- a/app/src/main/java/app/milanherke/mystudiez/ExamsFragment.kt
+++ b/app/src/main/java/app/milanherke/mystudiez/ExamsFragment.kt
@@ -148,7 +148,7 @@ class ExamsFragment : Fragment(), ExamsRecyclerViewAdapter.OnExamClickListener {
         viewModel.examsListLiveData.observe(
             this,
             Observer { list ->
-                val sortedList = ArrayList(list.sortedWith(compareBy(Exam::name)))
+                val sortedList = ArrayList(list.sortedWith(compareBy(Exam::date, Exam::name)))
                 examsAdapter.swapExamsList(sortedList)
                 if (exam_list != null && list.size != 0) Animations.runLayoutAnimation(exam_list)
             }

--- a/app/src/main/java/app/milanherke/mystudiez/ExamsRecyclerViewAdapter.kt
+++ b/app/src/main/java/app/milanherke/mystudiez/ExamsRecyclerViewAdapter.kt
@@ -151,7 +151,7 @@ class ExamsRecyclerViewAdapter(
             // Meaning we do not have to load nor display the subject details
             if (usedIn == SUBJECT_DETAILS) {
                 containerView.details_list_title.text = exam.name
-                containerView.details_list_header1.text = exam.date
+                containerView.details_list_header1.text = CalendarUtils.dateToString(exam.date, false)
                 containerView.details_list_header2.visibility = View.GONE
                 containerView.details_list_subject_indicator.visibility = View.GONE
 
@@ -184,13 +184,11 @@ class ExamsRecyclerViewAdapter(
                         } else {
                             containerView.details_list_title.text = exam.name
                             containerView.details_list_header1.text = subject.name
-                            containerView.details_list_header2.text = exam.date
+                            containerView.details_list_header2.text = CalendarUtils.dateToString(exam.date, false)
                         }
 
                         //We're creating a clone drawable because we do not want to affect other instances of the original drawable
-                        val clone =
-                            containerView.resources.getDrawable(R.drawable.placeholder_circle, null)
-                                .mutatedClone()
+                        val clone = containerView.resources.getDrawable(R.drawable.placeholder_circle, null).mutatedClone()
                         clone.setColor(subject.colorCode, containerView.context)
                         containerView.details_list_subject_indicator.setImageDrawable(clone)
                     }

--- a/app/src/main/java/app/milanherke/mystudiez/MainActivity.kt
+++ b/app/src/main/java/app/milanherke/mystudiez/MainActivity.kt
@@ -563,13 +563,10 @@ class MainActivity : AppCompatActivity(),
      */
 
     override fun onSaveExamClickListener(exam: Exam, subject: Subject) {
-        if (exam.reminder.isNotEmpty() && exam.reminder != getString(R.string.add_edit_lesson_btn)) {
+        val reminder = exam.reminder
+        if (reminder != null) {
             val notification =
                 createNotification(getString(R.string.notification_exam_reminder_title), exam.name)
-            val reminder = SimpleDateFormat(
-                "dd/MM/yyyy hh:mm:ss",
-                Locale.getDefault()
-            ).parse(exam.reminder + ":00")
             val delay = reminder.time.minus(System.currentTimeMillis())
             scheduleNotification(notification, delay, null, exam)
         }

--- a/app/src/main/java/app/milanherke/mystudiez/MainActivity.kt
+++ b/app/src/main/java/app/milanherke/mystudiez/MainActivity.kt
@@ -112,7 +112,7 @@ class MainActivity : AppCompatActivity(),
 
     override fun onOptionsItemSelected(item: MenuItem): Boolean {
         // Handle action bar item clicks here. The action bar will
-        // automatically handle clicks on the Home/Up button, so long
+        // automatically handle clicks on the Home/Up button, as long
         // as you specify a parent activity in AndroidManifest.xml.
         val fragment = findFragmentById(R.id.fragment_container)
         when (item.itemId) {

--- a/app/src/main/java/app/milanherke/mystudiez/MainActivity.kt
+++ b/app/src/main/java/app/milanherke/mystudiez/MainActivity.kt
@@ -532,13 +532,10 @@ class MainActivity : AppCompatActivity(),
      */
 
     override fun onSaveTaskClickListener(task: Task, subject: Subject) {
-        if (task.reminder.isNotEmpty()) {
+        val reminder = task.reminder
+        if (reminder != null) {
             val notification =
                 createNotification(getString(R.string.notification_task_reminder_title), task.name)
-            val reminder = SimpleDateFormat(
-                "dd/MM/yyyy hh:mm:ss",
-                Locale.getDefault()
-            ).parse(task.reminder + ":00")
             val delay = reminder.time.minus(System.currentTimeMillis())
             scheduleNotification(notification, delay, task, null)
         }

--- a/app/src/main/java/app/milanherke/mystudiez/OverviewFragment.kt
+++ b/app/src/main/java/app/milanherke/mystudiez/OverviewFragment.kt
@@ -13,7 +13,7 @@ import androidx.fragment.app.Fragment
 import androidx.lifecycle.Observer
 import androidx.lifecycle.ViewModelProviders
 import androidx.recyclerview.widget.LinearLayoutManager
-import app.milanherke.mystudiez.CalendarUtils.Companion.DateSet
+import app.milanherke.mystudiez.CalendarUtils.Companion.CalendarInteractions
 import app.milanherke.mystudiez.Fragments.OVERVIEW
 import app.milanherke.mystudiez.OverviewViewModel.DataFetching
 import com.google.firebase.database.DatabaseError
@@ -202,10 +202,12 @@ class OverviewFragment : Fragment(),
                 activity!!,
                 R.id.overview_date_button,
                 cal,
-                object : DateSet {
-                    override fun onSuccess(date: Date) {
+                object : CalendarInteractions {
+                    override fun onDateSet(date: Date) {
                         viewModel.loadAllDetails(date, dataFetchingListener)
                     }
+
+                    override fun onTimeSet(date: Date) {}
                 })
             DatePickerDialog(
                 context!!, listener,

--- a/app/src/main/java/app/milanherke/mystudiez/OverviewFragment.kt
+++ b/app/src/main/java/app/milanherke/mystudiez/OverviewFragment.kt
@@ -162,7 +162,8 @@ class OverviewFragment : Fragment(),
         viewModel.lessonsListLiveData.observe(
             this,
             Observer { list ->
-                lessonsAdapter.swapLessonsList(list)
+                val sortedList = ArrayList(list.sortedWith(compareBy(Lesson::starts)))
+                lessonsAdapter.swapLessonsList(sortedList)
                 if (overview_schedule_list != null && list.size != 0) Animations.runLayoutAnimation(
                     overview_schedule_list
                 )
@@ -171,7 +172,8 @@ class OverviewFragment : Fragment(),
         viewModel.tasksListLiveData.observe(
             this,
             Observer { list ->
-                tasksAdapter.swapTasksList(list)
+                val sortedList = ArrayList(list.sortedWith(compareBy(Task::name)))
+                tasksAdapter.swapTasksList(sortedList)
                 if (overview_task_list != null && list.size != 0) Animations.runLayoutAnimation(
                     overview_task_list
                 )
@@ -180,7 +182,8 @@ class OverviewFragment : Fragment(),
         viewModel.examsListLiveData.observe(
             this,
             Observer { list ->
-                examsAdapter.swapExamsList(list)
+                val sortedList = ArrayList(list.sortedWith(compareBy(Exam::name)))
+                examsAdapter.swapExamsList(sortedList)
                 if (overview_exam_list != null && list.size != 0) Animations.runLayoutAnimation(
                     overview_exam_list
                 )

--- a/app/src/main/java/app/milanherke/mystudiez/OverviewViewModel.kt
+++ b/app/src/main/java/app/milanherke/mystudiez/OverviewViewModel.kt
@@ -13,7 +13,6 @@ import com.google.firebase.database.ktx.getValue
 import com.google.firebase.ktx.Firebase
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.launch
-import java.text.SimpleDateFormat
 import java.util.*
 
 /**
@@ -159,7 +158,7 @@ class OverviewViewModel(application: Application) : AndroidViewModel(application
     ) {
         GlobalScope.launch {
             listener.onLoad()
-            val currentDate = SimpleDateFormat("dd/MM/yyyy").format(date)
+            val currentDate = Date(CalendarUtils.roundToMidnight(date.time))
             val exams: ArrayList<Exam> = arrayListOf()
             val database = Firebase.database
             val ref = database.getReference("exams/${FirebaseUtils.getUserId()}")

--- a/app/src/main/java/app/milanherke/mystudiez/OverviewViewModel.kt
+++ b/app/src/main/java/app/milanherke/mystudiez/OverviewViewModel.kt
@@ -116,7 +116,7 @@ class OverviewViewModel(application: Application) : AndroidViewModel(application
     ) {
         GlobalScope.launch {
             listener.onLoad()
-            val currentDate = SimpleDateFormat("dd/MM/yyyy").format(date)
+            val currentDate = Date(CalendarUtils.roundToMidnight(date.time))
             val tasks: ArrayList<Task> = arrayListOf()
             val database = Firebase.database
             val ref = database.getReference("tasks/${FirebaseUtils.getUserId()}")

--- a/app/src/main/java/app/milanherke/mystudiez/SubjectDetailsFragment.kt
+++ b/app/src/main/java/app/milanherke/mystudiez/SubjectDetailsFragment.kt
@@ -187,7 +187,7 @@ class SubjectDetailsFragment : Fragment(),
         viewModel.selectedExamsLiveData.observe(
             this,
             Observer { list ->
-                val sortedList = ArrayList(list.sortedWith(compareBy(Exam::date)))
+                val sortedList = ArrayList(list.sortedWith(compareBy(Exam::date, Exam::name)))
                 examsAdapter.swapExamsList(sortedList) }
         )
         viewModel.loadAllDetails(subject!!.id, dataFetchingListener)

--- a/app/src/main/java/app/milanherke/mystudiez/SubjectDetailsFragment.kt
+++ b/app/src/main/java/app/milanherke/mystudiez/SubjectDetailsFragment.kt
@@ -174,15 +174,21 @@ class SubjectDetailsFragment : Fragment(),
         // Registering observers
         viewModel.selectedLessonsLiveData.observe(
             this,
-            Observer { list -> lessonsAdapter.swapLessonsList(list) }
+            Observer { list ->
+                val sortedList = ArrayList(list.sortedWith(compareBy(Lesson::day)))
+                lessonsAdapter.swapLessonsList(sortedList) }
         )
         viewModel.selectedTasksLiveData.observe(
             this,
-            Observer { list -> tasksAdapter.swapTasksList(list) }
+            Observer { list ->
+                val sortedList = ArrayList(list.sortedWith(compareBy(Task::dueDate)))
+                tasksAdapter.swapTasksList(sortedList) }
         )
         viewModel.selectedExamsLiveData.observe(
             this,
-            Observer { list -> examsAdapter.swapExamsList(list) }
+            Observer { list ->
+                val sortedList = ArrayList(list.sortedWith(compareBy(Exam::date)))
+                examsAdapter.swapExamsList(sortedList) }
         )
         viewModel.loadAllDetails(subject!!.id, dataFetchingListener)
     }

--- a/app/src/main/java/app/milanherke/mystudiez/SubjectDetailsFragment.kt
+++ b/app/src/main/java/app/milanherke/mystudiez/SubjectDetailsFragment.kt
@@ -175,13 +175,13 @@ class SubjectDetailsFragment : Fragment(),
         viewModel.selectedLessonsLiveData.observe(
             this,
             Observer { list ->
-                val sortedList = ArrayList(list.sortedWith(compareBy(Lesson::day)))
+                val sortedList = ArrayList(list.sortedWith(compareBy(Lesson::day, Lesson::starts)))
                 lessonsAdapter.swapLessonsList(sortedList) }
         )
         viewModel.selectedTasksLiveData.observe(
             this,
             Observer { list ->
-                val sortedList = ArrayList(list.sortedWith(compareBy(Task::dueDate)))
+                val sortedList = ArrayList(list.sortedWith(compareBy(Task::dueDate, Task::name)))
                 tasksAdapter.swapTasksList(sortedList) }
         )
         viewModel.selectedExamsLiveData.observe(

--- a/app/src/main/java/app/milanherke/mystudiez/SubjectsFragment.kt
+++ b/app/src/main/java/app/milanherke/mystudiez/SubjectsFragment.kt
@@ -3,6 +3,7 @@ package app.milanherke.mystudiez
 import android.annotation.SuppressLint
 import android.content.Context
 import android.os.Bundle
+import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -63,7 +64,6 @@ class SubjectsFragment : Fragment(), SubjectsRecyclerViewAdapter.OnSubjectClickL
         inflater: LayoutInflater, container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View? {
-
         // Inflate the layout for this fragment
         return inflater.inflate(R.layout.fragment_subjects, container, false)
     }
@@ -71,7 +71,6 @@ class SubjectsFragment : Fragment(), SubjectsRecyclerViewAdapter.OnSubjectClickL
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         activity!!.toolbar.setTitle(R.string.subjects_title)
-
         subject_list.layoutManager = LinearLayoutManager(context)
         subject_list.adapter = subjectsAdapter
     }
@@ -79,7 +78,6 @@ class SubjectsFragment : Fragment(), SubjectsRecyclerViewAdapter.OnSubjectClickL
     @SuppressLint("RestrictedApi")
     override fun onActivityCreated(savedInstanceState: Bundle?) {
         super.onActivityCreated(savedInstanceState)
-
         if (activity is AppCompatActivity) {
             (activity as AppCompatActivity?)?.supportActionBar?.setDisplayHomeAsUpEnabled(false)
         }
@@ -112,7 +110,8 @@ class SubjectsFragment : Fragment(), SubjectsRecyclerViewAdapter.OnSubjectClickL
         viewModel.subjectsListLiveData.observe(
             this,
             Observer { list ->
-                subjectsAdapter.swapSubjectsList(list)
+                val sortedList = ArrayList(list.sortedWith(compareBy(Subject::name, Subject::teacher)))
+                subjectsAdapter.swapSubjectsList(sortedList)
                 if (subject_list != null && list.size != 0) Animations.runLayoutAnimation(
                     subject_list
                 )

--- a/app/src/main/java/app/milanherke/mystudiez/SubjectsRecyclerViewAdapter.kt
+++ b/app/src/main/java/app/milanherke/mystudiez/SubjectsRecyclerViewAdapter.kt
@@ -148,6 +148,9 @@ class SubjectsRecyclerViewAdapter(
             days: ArrayList<Int>,
             listener: OnSubjectClickListener
         ) {
+
+            setViewToDefault()
+
             containerView.sli_name.text = subject.name
             for (day in days) {
                 when (day) {
@@ -220,6 +223,59 @@ class SubjectsRecyclerViewAdapter(
             containerView.sli_linearlayout.setOnClickListener {
                 listener.onSubjectClick(subject)
             }
+
+        }
+
+        private fun setViewToDefault() {
+            containerView.sli_sunday.setBackgroundResource(R.drawable.has_no_lesson_on_day)
+            containerView.sli_sunday.setTextColor(
+                ContextCompat.getColor(
+                    containerView.context,
+                    R.color.colorTextPrimary
+                )
+            )
+            containerView.sli_monday.setBackgroundResource(R.drawable.has_no_lesson_on_day)
+            containerView.sli_monday.setTextColor(
+                ContextCompat.getColor(
+                    containerView.context,
+                    R.color.colorTextPrimary
+                )
+            )
+            containerView.sli_tuesday.setBackgroundResource(R.drawable.has_no_lesson_on_day)
+            containerView.sli_tuesday.setTextColor(
+                ContextCompat.getColor(
+                    containerView.context,
+                    R.color.colorTextPrimary
+                )
+            )
+            containerView.sli_wednesday.setBackgroundResource(R.drawable.has_no_lesson_on_day)
+            containerView.sli_wednesday.setTextColor(
+                ContextCompat.getColor(
+                    containerView.context,
+                    R.color.colorTextPrimary
+                )
+            )
+            containerView.sli_thursday.setBackgroundResource(R.drawable.has_no_lesson_on_day)
+            containerView.sli_thursday.setTextColor(
+                ContextCompat.getColor(
+                    containerView.context,
+                    R.color.colorTextPrimary
+                )
+            )
+            containerView.sli_friday.setBackgroundResource(R.drawable.has_no_lesson_on_day)
+            containerView.sli_friday.setTextColor(
+                ContextCompat.getColor(
+                    containerView.context,
+                    R.color.colorTextPrimary
+                )
+            )
+            containerView.sli_saturday.setBackgroundResource(R.drawable.has_no_lesson_on_day)
+            containerView.sli_saturday.setTextColor(
+                ContextCompat.getColor(
+                    containerView.context,
+                    R.color.colorTextPrimary
+                )
+            )
         }
 
     }

--- a/app/src/main/java/app/milanherke/mystudiez/Task.kt
+++ b/app/src/main/java/app/milanherke/mystudiez/Task.kt
@@ -2,6 +2,7 @@ package app.milanherke.mystudiez
 
 import android.os.Parcelable
 import kotlinx.android.parcel.Parcelize
+import java.util.*
 
 /**
  * Data [Parcelable] subclass.
@@ -21,9 +22,9 @@ data class Task(
     var description: String,
     var type: Int,
     var subjectId: String,
-    var dueDate: String,
-    var reminder: String,
+    var dueDate: Date,
+    var reminder: Date? = null,
     var id: String = ""
 ) : Parcelable {
-    constructor() : this("", "", -1, "", "", "", "")
+    constructor() : this("", "", -1, "", Date(), null, "")
 }

--- a/app/src/main/java/app/milanherke/mystudiez/TaskDetailsFragment.kt
+++ b/app/src/main/java/app/milanherke/mystudiez/TaskDetailsFragment.kt
@@ -57,6 +57,7 @@ class TaskDetailsFragment : Fragment() {
 
         // Avoiding problems with smart-cast
         val task = task
+        val taskReminder = task?.reminder
         val subject = subject
 
         if (task != null && subject != null) {
@@ -65,8 +66,8 @@ class TaskDetailsFragment : Fragment() {
             task_details_desc_value.text = task.description
             task_details_type_value.text = TaskUtils.getTaskType(task.type, context!!)
             task_details_subject_value.text = subject.name
-            task_details_due_date_value.text = task.dueDate
-            task_details_reminder_value.text = task.reminder
+            task_details_due_date_value.text = CalendarUtils.dateToString(task.dueDate, false)
+            task_details_reminder_value.text = if (taskReminder != null) CalendarUtils.dateToString(taskReminder, true) else getString(R.string.add_edit_lesson_btn)
         }
     }
 

--- a/app/src/main/java/app/milanherke/mystudiez/TasksFragment.kt
+++ b/app/src/main/java/app/milanherke/mystudiez/TasksFragment.kt
@@ -143,7 +143,7 @@ class TasksFragment : Fragment(), TasksRecyclerViewAdapter.OnTaskClickListener {
         viewModel.tasksListLiveData.observe(
             this,
             Observer { list ->
-                val sortedList = ArrayList(list.sortedWith(compareBy(Task::name)))
+                val sortedList = ArrayList(list.sortedWith(compareBy(Task::dueDate, Task::name)))
                 tasksAdapter.swapTasksList(sortedList)
                 if (task_list != null && list.size != 0) Animations.runLayoutAnimation(task_list)
             }

--- a/app/src/main/java/app/milanherke/mystudiez/TasksFragment.kt
+++ b/app/src/main/java/app/milanherke/mystudiez/TasksFragment.kt
@@ -143,7 +143,8 @@ class TasksFragment : Fragment(), TasksRecyclerViewAdapter.OnTaskClickListener {
         viewModel.tasksListLiveData.observe(
             this,
             Observer { list ->
-                tasksAdapter.swapTasksList(list)
+                val sortedList = ArrayList(list.sortedWith(compareBy(Task::name)))
+                tasksAdapter.swapTasksList(sortedList)
                 if (task_list != null && list.size != 0) Animations.runLayoutAnimation(task_list)
             }
         )

--- a/app/src/main/java/app/milanherke/mystudiez/TasksRecyclerViewAdapter.kt
+++ b/app/src/main/java/app/milanherke/mystudiez/TasksRecyclerViewAdapter.kt
@@ -152,7 +152,7 @@ class TasksRecyclerViewAdapter(
             // Meaning we do not have to load nor display the subject details
             if (usedIn == SUBJECT_DETAILS) {
                 containerView.details_list_title.text = task.name
-                containerView.details_list_header1.text = task.dueDate
+                containerView.details_list_header1.text = CalendarUtils.dateToString(task.dueDate, false)
                 containerView.details_list_header2.text =
                     TaskUtils.getTaskType(task.type, containerView.context)
                 containerView.details_list_subject_indicator.visibility = View.GONE
@@ -191,7 +191,7 @@ class TasksRecyclerViewAdapter(
                                     subject.name,
                                     TaskUtils.getTaskType(task.type, containerView.context)
                                 )
-                            containerView.details_list_header2.text = task.dueDate
+                            containerView.details_list_header2.text = CalendarUtils.dateToString(task.dueDate, false)
                         }
 
                         //Creating a clone drawable because we do not want to affect other instances of the original drawable

--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ buildscript {
         
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.6.1'
+        classpath 'com.android.tools.build:gradle:4.0.0'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath 'com.google.gms:google-services:4.3.3'
         // NOTE: Do not place your application dependencies here; they belong

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Sat Mar 14 13:58:38 CET 2020
+#Fri May 29 12:56:06 CEST 2020
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.1.1-all.zip


### PR DESCRIPTION
## #28 
- Subjects are displayed alphabetically
- Lessons are displayed from Sunday to Saturday
- Tasks and exams are displayed based on their dates (Earliest events first)

## #30 
- Bug fixed, there are no duplicates anymore
     - Had to reset the ViewHolder to its default state before the view gets reused

## #31 
- Exam and task dates and reminders are stored as Date objects in Firebase 